### PR TITLE
Configure Vercel build for Next.js app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "builds": [
+    { "src": "apps/web/package.json", "use": "@vercel/next" }
+  ],
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm --filter @cyberidle/web... build"
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to build `apps/web` with the Next.js runtime and ensure pnpm install/build

## Testing
- `npx --yes vercel build --token test` *(fails: No Project Settings retrieved)*

------
https://chatgpt.com/codex/tasks/task_e_6898a19d490483318dd18c586da74723