### PR TITLE
Improve action flow and toast feedback

### DIFF
--- a/apps/web/components/actions/ActionCard.tsx
+++ b/apps/web/components/actions/ActionCard.tsx
@@ -2,6 +2,7 @@ import { ActionDef } from '@cyberidle/game-core';
 import { useGameStore } from '../../store/useGameStore';
 import { Button } from '../ui/Button';
 import { Card } from '../ui/Card';
+import { formatDuration } from '../../utils/time';
 
 export function ActionCard({ action }: { action: ActionDef }) {
   const start = useGameStore((s) => s.startActionById);
@@ -11,7 +12,7 @@ export function ActionCard({ action }: { action: ActionDef }) {
     <Card className="flex items-center justify-between">
       <div>
         <h3 className="text-primary">{action.title}</h3>
-        <p className="text-secondary text-sm">{Math.round(action.durationMs / 1000)}s</p>
+        <p className="text-secondary text-sm">{formatDuration(action.durationMs)}</p>
       </div>
       {active ? (
         <Button onClick={() => stop()}>Stop</Button>

--- a/apps/web/components/actions/ActiveActionBar.tsx
+++ b/apps/web/components/actions/ActiveActionBar.tsx
@@ -1,13 +1,24 @@
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { useGameStore } from '../../store/useGameStore';
 import { ProgressBar } from '../ui/ProgressBar';
 
 export function ActiveActionBar() {
   const run = useGameStore((s) => s.activeRun);
   const getAction = useGameStore((s) => s.getActionById);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (!run) return;
+    const update = () =>
+      setProgress(((Date.now() - run.startedAt) / run.durationMs) * 100);
+    update();
+    const handle = setInterval(update, 250);
+    return () => clearInterval(handle);
+  }, [run]);
+
   if (!run) return null;
   const action = getAction(run.actionId);
-  const progress = ((Date.now() - run.startedAt) / run.durationMs) * 100;
   if (!action) return null;
   return (
     <Link

--- a/apps/web/components/feedback/Toast.tsx
+++ b/apps/web/components/feedback/Toast.tsx
@@ -4,6 +4,16 @@ export interface ToastProps {
   kind?: 'info' | 'success' | 'error';
 }
 
-export function Toast({ text }: ToastProps) {
-  return <div className="bg-surface text-primary px-4 py-2 rounded shadow-neon">{text}</div>;
+/**
+ * Toast message component.
+ * Available kinds: `info`, `success`, `error`.
+ */
+export function Toast({ text, kind = 'info' }: ToastProps) {
+  const kindClass =
+    kind === 'success'
+      ? 'bg-green-600 text-white'
+      : kind === 'error'
+        ? 'bg-red-600 text-white'
+        : 'bg-surface text-primary';
+  return <div className={`${kindClass} px-4 py-2 rounded shadow-neon`}>{text}</div>;
 }

--- a/apps/web/store/useGameStore.ts
+++ b/apps/web/store/useGameStore.ts
@@ -27,8 +27,15 @@ export const useGameStore = create<GameSlice>((set, get) => ({
     if (!action) return;
     try {
       set((state) => coreStart(state, action));
-    } catch {
-      // ignore
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'unknown_error';
+      const text =
+        msg === 'not_enough_energy'
+          ? 'Not enough energy'
+          : msg === 'action_already_running'
+            ? 'Action already running'
+            : 'Unable to start action';
+      useUIStore.getState().pushToast({ text, kind: 'error' });
     }
   },
   stopAction: () => set((state) => coreStop(state)),

--- a/apps/web/store/useUIStore.ts
+++ b/apps/web/store/useUIStore.ts
@@ -12,10 +12,25 @@ interface UIState {
   removeToast: (id: string) => void;
 }
 
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
 export const useUIStore = create<UIState>((set) => ({
   toasts: [],
-  pushToast: (t) =>
-    set((s) => ({ toasts: [...s.toasts, { id: Date.now().toString(), ...t }] })),
-  removeToast: (id) =>
-    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+  pushToast: (t) => {
+    const id = crypto.randomUUID();
+    const timeout = setTimeout(() => {
+      timers.delete(id);
+      set((s) => ({ toasts: s.toasts.filter((toast) => toast.id !== id) }));
+    }, 3000);
+    timers.set(id, timeout);
+    set((s) => ({ toasts: [...s.toasts, { id, ...t }] }));
+  },
+  removeToast: (id) => {
+    const timeout = timers.get(id);
+    if (timeout) {
+      clearTimeout(timeout);
+      timers.delete(id);
+    }
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }));
+  }
 }));

--- a/packages/content/actions.json
+++ b/packages/content/actions.json
@@ -6,7 +6,9 @@
     "title": "Crack Neighborhood ISP",
     "durationMs": 30000,
     "cost": { "energy": 6 },
-    "requirements": [],
+    "requirements": [
+      { "type": "skill", "skill": "hacking", "level": 1 }
+    ],
     "rewards": { "xp": { "hacking": 12 }, "dropTableId": "dt_data_low" },
     "meta": { "failChanceBase": 0.12, "difficulty": "easy" }
   }

--- a/packages/game-core/actions.ts
+++ b/packages/game-core/actions.ts
@@ -1,6 +1,9 @@
 import { ActionDef, GameState, ActionRun } from './types';
 
 export function startAction(state: GameState, action: ActionDef, now = Date.now()): GameState {
+  if (state.activeRun) {
+    throw new Error('action_already_running');
+  }
   if (state.energy < action.cost.energy) {
     throw new Error('not_enough_energy');
   }

--- a/packages/game-core/package.json
+++ b/packages/game-core/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -p tsconfig.json"
   },
   "devDependencies": {
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@types/node": "^24.2.1"
   }
 }

--- a/packages/game-core/rewards.test.ts
+++ b/packages/game-core/rewards.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { rollDropTable } from './rewards.js';
+
+test('rollDropTable returns empty when total weight is zero', () => {
+  const result = rollDropTable([
+    { itemId: 'a', weight: 0, qtyMin: 1, qtyMax: 1 },
+    { itemId: 'b', weight: 0, qtyMin: 1, qtyMax: 1 }
+  ]);
+  assert.deepEqual(result, {});
+});

--- a/packages/game-core/rewards.ts
+++ b/packages/game-core/rewards.ts
@@ -3,6 +3,7 @@ import { ActionDef, DropTableEntry, GameState } from './types';
 export function rollDropTable(entries: DropTableEntry[]): Record<string, number> {
   if (!entries.length) return {};
   const total = entries.reduce((sum, e) => sum + e.weight, 0);
+  if (total <= 0) return {};
   const roll = Math.random() * total;
   let acc = 0;
   for (const e of entries) {

--- a/packages/game-core/types.ts
+++ b/packages/game-core/types.ts
@@ -3,6 +3,12 @@ export interface Rewards {
   dropTableId?: string;
 }
 
+export interface Requirement {
+  type: string;
+  skill?: string;
+  level?: number;
+}
+
 export interface ActionDef {
   id: string;
   districtId: string;
@@ -10,7 +16,7 @@ export interface ActionDef {
   title: string;
   durationMs: number;
   cost: { energy: number };
-  requirements: any[];
+  requirements: Requirement[];
   rewards: Rewards;
   meta?: Record<string, any>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
 
   packages/game-core:
     devDependencies:
+      '@types/node':
+        specifier: ^24.2.1
+        version: 24.2.1
       typescript:
         specifier: ^5.3.3
         version: 5.9.2


### PR DESCRIPTION
## Summary
- Prevent starting a new action while one is running
- Show action progress continuously in the active action bar
- Style and auto-dismiss toasts with reliable IDs
- Handle zero-weight drop tables and add a test
- Typedef action requirements and use shared duration formatter

## Testing
- `pnpm --filter @cyberidle/game-core build`
- `node --test packages/game-core/dist/rewards.test.js`
- `pnpm --filter @cyberidle/web build`


------
https://chatgpt.com/codex/tasks/task_e_6898c216c9688331b388e7632bbfc43d