### PR TITLE
fix: server redirect for root

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,10 +1,14 @@
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import type { GetServerSideProps } from 'next';
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: '/map',
+      permanent: false,
+    },
+  };
+};
 
 export default function Index() {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace('/map');
-  }, [router]);
   return null;
 }


### PR DESCRIPTION
## Summary
- redirect root URL to `/map` using `getServerSideProps`

## Testing
- `pnpm --filter @cyberidle/web... build`

------
https://chatgpt.com/codex/tasks/task_e_6898c9e079508331ab958fcc45edd679