### PR TITLE
Integrate resource and building system with seasonal modifiers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,119 +1,199 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { RESOURCES, BUILDINGS, SEASONS } from './data';
 
-const RESOURCES = {
-  food: { label: 'Food' },
-  scrap: { label: 'Scrap' }
-};
+const RESOURCE_CATEGORIES = Object.values(RESOURCES).reduce((acc, r) => {
+  (acc[r.category] ||= []).push(r.id);
+  return acc;
+}, {});
 
-const BUILDINGS = {
-  greenhouse: {
-    label: 'Greenhouse',
-    cost: { scrap: 20 },
-    effect: { food: 1 }
-  },
-  scrapyard: {
-    label: 'Scrap Yard',
-    cost: { scrap: 10 },
-    effect: { scrap: 0.5 }
-  }
-};
+const BUILDING_CATEGORIES = Object.values(BUILDINGS).reduce((acc, b) => {
+  (acc[b.category] ||= []).push(b.id);
+  return acc;
+}, {});
 
-function App() {
-  const [survivors, setSurvivors] = useState(5);
-  const [resources, setResources] = useState({ food: 50, scrap: 0 });
-  const [buildings, setBuildings] = useState({ greenhouse: 0, scrapyard: 0 });
+function getCapacity(resourceId, buildingCounts) {
+  let cap = RESOURCES[resourceId].baseCapacity;
+  Object.values(BUILDINGS).forEach(b => {
+    if (b.addsCapacity && b.addsCapacity[resourceId]) {
+      cap += b.addsCapacity[resourceId] * (buildingCounts[b.id] || 0);
+    }
+  });
+  return cap;
+}
+
+function calculateRates(buildingCounts, seasonMods) {
+  const rates = {};
+  Object.values(BUILDINGS).forEach(b => {
+    const count = buildingCounts[b.id] || 0;
+    if (!b.outputResource || count === 0) return;
+    const speed = seasonMods[b.seasonSpeedKey] || 1;
+    const yieldMod = seasonMods[b.seasonYieldKey] || 1;
+    const perSec = (b.harvestAmount * b.outputValue * yieldMod) / (b.cycleTimeSec / speed);
+    rates[b.outputResource] = (rates[b.outputResource] || 0) + perSec * count;
+  });
+  return rates;
+}
+
+function getScaledCost(buildingId, countAlreadyBuilt) {
+  const base = BUILDINGS[buildingId].cost;
+  const cost = {};
+  Object.entries(base).forEach(([res, amt]) => {
+    cost[res] = Math.ceil(amt * Math.pow(1.15, countAlreadyBuilt));
+  });
+  return cost;
+}
+
+function formatCost(cost) {
+  return Object.entries(cost)
+    .filter(([, v]) => v > 0)
+    .map(([res, amt]) => `${amt} ${RESOURCES[res].name}`)
+    .join(', ');
+}
+
+function Sidebar({ resources, capacities, rates }) {
+  return (
+    <aside style={{ width: '250px', background: '#222', color: '#fff', padding: '1rem' }}>
+      {Object.entries(RESOURCE_CATEGORIES).map(([cat, ids]) => (
+        <div key={cat} style={{ marginBottom: '1rem' }}>
+          <h3 style={{ textTransform: 'capitalize', margin: '0 0 0.5rem 0' }}>{cat}</h3>
+          {ids.map(id => {
+            const rate = rates[id] || 0;
+            return (
+              <div key={id} style={{ fontSize: '0.9rem', marginBottom: '0.25rem' }}>
+                {RESOURCES[id].name}: {resources[id].toFixed(1)} / {capacities[id]} (
+                {rate >= 0 ? '+' : ''}{rate.toFixed(1)}/s)
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </aside>
+  );
+}
+
+export default function App() {
+  const initialResources = useMemo(() => {
+    const obj = {};
+    Object.keys(RESOURCES).forEach(id => (obj[id] = 0));
+    return obj;
+  }, []);
+  const initialBuildings = useMemo(() => {
+    const obj = {};
+    Object.values(BUILDINGS).forEach(b => (obj[b.id] = b.startsWithCount || 0));
+    return obj;
+  }, []);
+
+  const [resources, setResources] = useState(initialResources);
+  const [buildings, setBuildings] = useState(initialBuildings);
+  const [season, setSeason] = useState('spring');
+
+  const seasonMods = SEASONS[season];
+
+  const capacities = useMemo(() => {
+    const caps = {};
+    Object.keys(RESOURCES).forEach(id => {
+      caps[id] = getCapacity(id, buildings);
+    });
+    return caps;
+  }, [buildings]);
+
+  const rates = useMemo(() => calculateRates(buildings, seasonMods), [buildings, seasonMods]);
 
   useEffect(() => {
     const id = setInterval(() => {
-      setResources(r => {
-        const next = { ...r };
-        next.food = +(next.food + survivors * 0.2).toFixed(1);
-        next.scrap = +(next.scrap + 0.1).toFixed(1);
-        Object.entries(buildings).forEach(([key, count]) => {
-          const eff = BUILDINGS[key].effect;
-          Object.entries(eff).forEach(([res, val]) => {
-            next[res] = +(next[res] + val * count).toFixed(1);
-          });
+      setResources(prev => {
+        const next = { ...prev };
+        Object.keys(RESOURCES).forEach(resId => {
+          const rate = rates[resId] || 0;
+          if (rate !== 0) {
+            next[resId] = Math.min(capacities[resId], +(next[resId] + rate).toFixed(2));
+          }
         });
         return next;
       });
     }, 1000);
     return () => clearInterval(id);
-  }, [survivors, buildings]);
+  }, [rates, capacities]);
 
-  const scavenge = () => setResources(r => ({ ...r, food: r.food + 1 }));
-
-  const recruit = () => {
-    if (resources.food >= 10) {
-      setResources(r => ({ ...r, food: r.food - 10 }));
-      setSurvivors(s => s + 1);
-    }
-  };
-
-  const build = key => {
-    const b = BUILDINGS[key];
-    const canBuild = Object.entries(b.cost).every(([res, cost]) => resources[res] >= cost);
-    if (!canBuild) return;
-    setResources(r => {
-      const next = { ...r };
-      Object.entries(b.cost).forEach(([res, cost]) => {
-        next[res] -= cost;
+  const build = id => {
+    const count = buildings[id] || 0;
+    const cost = getScaledCost(id, count);
+    const canAfford = Object.entries(cost).every(([res, amt]) => resources[res] >= amt);
+    if (!canAfford) return;
+    const newBuildings = { ...buildings, [id]: count + 1 };
+    setBuildings(newBuildings);
+    setResources(prev => {
+      const next = { ...prev };
+      Object.entries(cost).forEach(([res, amt]) => {
+        next[res] = +(next[res] - amt).toFixed(2);
       });
       return next;
     });
-    setBuildings(bs => ({ ...bs, [key]: bs[key] + 1 }));
   };
 
-  const resourceBarStyle = {
-    display: 'flex',
-    gap: '1rem',
-    flexWrap: 'wrap',
-    background: '#222',
-    color: '#fff',
-    padding: '0.5rem',
-    borderRadius: '4px'
+  const demolish = id => {
+    const count = buildings[id];
+    if (count <= 0) return;
+    const cost = getScaledCost(id, count - 1);
+    const newBuildings = { ...buildings, [id]: count - 1 };
+    setBuildings(newBuildings);
+    setResources(prev => {
+      const next = { ...prev };
+      Object.entries(cost).forEach(([res, amt]) => {
+        const refund = amt * 0.5;
+        const cap = getCapacity(res, newBuildings);
+        next[res] = Math.min(cap, +(next[res] + refund).toFixed(2));
+      });
+      Object.keys(next).forEach(resId => {
+        const cap = getCapacity(resId, newBuildings);
+        next[resId] = Math.min(next[resId], cap);
+      });
+      return next;
+    });
   };
 
   return (
-    <div style={{ padding: '1rem', fontFamily: 'sans-serif', maxWidth: '480px', margin: '0 auto' }}>
-      <h1>Wasteland Camp</h1>
-      <div style={resourceBarStyle}>
-        <span>Survivors: {survivors}</span>
-        {Object.keys(RESOURCES).map(key => (
-          <span key={key}>
-            {RESOURCES[key].label}: {resources[key].toFixed(1)}
-          </span>
+    <div style={{ display: 'flex', minHeight: '100vh', fontFamily: 'sans-serif' }}>
+      <Sidebar resources={resources} capacities={capacities} rates={rates} />
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Apocalypse Idle</h1>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>
+            Season:{' '}
+            <select value={season} onChange={e => setSeason(e.target.value)}>
+              {Object.keys(SEASONS).map(key => (
+                <option key={key} value={key} style={{ textTransform: 'capitalize' }}>
+                  {key.charAt(0).toUpperCase() + key.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <h2>Buildings</h2>
+        {Object.entries(BUILDING_CATEGORIES).map(([cat, ids]) => (
+          <div key={cat} style={{ marginBottom: '1rem' }}>
+            <h3 style={{ textTransform: 'capitalize' }}>{cat}</h3>
+            {ids.map(id => {
+              const b = BUILDINGS[id];
+              const count = buildings[id] || 0;
+              const cost = getScaledCost(id, count);
+              const affordable = Object.entries(cost).every(([res, amt]) => resources[res] >= amt);
+              return (
+                <div key={id} style={{ marginBottom: '0.5rem' }}>
+                  <strong>{b.name}</strong> ({count})<br />
+                  <button onClick={() => build(id)} disabled={!affordable} style={{ marginRight: '0.5rem' }}>
+                    Build ({formatCost(cost)})
+                  </button>
+                  <button onClick={() => demolish(id)} disabled={count === 0}>
+                    Demolish (50% refund)
+                  </button>
+                </div>
+              );
+            })}
+          </div>
         ))}
-      </div>
-
-      <div style={{ marginTop: '1rem' }}>
-        <button onClick={scavenge}>Scavenge (+1 food)</button>
-        <button onClick={recruit} disabled={resources.food < 10} style={{ marginLeft: '1rem' }}>
-          Recruit Survivor (10 food)
-        </button>
-      </div>
-
-      <h2 style={{ marginTop: '1.5rem' }}>Buildings</h2>
-      <div>
-        {Object.keys(BUILDINGS).map(key => {
-          const b = BUILDINGS[key];
-          const affordable = Object.entries(b.cost).every(([res, cost]) => resources[res] >= cost);
-          return (
-            <button
-              key={key}
-              onClick={() => build(key)}
-              disabled={!affordable}
-              style={{ display: 'block', width: '100%', margin: '0.25rem 0', padding: '0.5rem', textAlign: 'left' }}
-            >
-              {b.label} ({buildings[key]}) - Cost: {Object.entries(b.cost)
-                .map(([res, cost]) => `${cost} ${RESOURCES[res].label}`)
-                .join(', ')}
-            </button>
-          );
-        })}
-      </div>
+      </main>
     </div>
   );
 }
 
-export default App;

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,30 @@
+export const RESOURCES = {
+  food: { id: 'food', name: 'Food', tier: 0, type: 'consumable', category: 'food', baseCapacity: 300, perStorage: 200, seasonalKeys: ['farmingSpeed', 'farmingYield'] },
+  wood: { id: 'wood', name: 'Wood', tier: 0, type: 'raw', category: 'resources', baseCapacity: 100, perStorage: 200, seasonalKeys: ['workSpeed', 'workYield'] },
+  plank: { id: 'plank', name: 'Planks', tier: 1, type: 'processed', category: 'resources', baseCapacity: 0, perStorage: 0, seasonalKeys: ['workSpeed', 'workYield'] },
+  scrap: { id: 'scrap', name: 'Scrap', tier: 0, type: 'raw', category: 'resources', baseCapacity: 100, perStorage: 200, seasonalKeys: ['workSpeed'] },
+  metal: { id: 'metal', name: 'Metal Bars', tier: 1, type: 'processed', category: 'resources', baseCapacity: 0, perStorage: 0, seasonalKeys: ['smeltingSpeed', 'smeltingYield'] },
+  water: { id: 'water', name: 'Water', tier: 0, type: 'consumable', category: 'food', baseCapacity: 100, perStorage: 200, seasonalKeys: ['workSpeed', 'seasonRain'] }
+};
+
+export const BUILDINGS = {
+  potatoField: { id: 'potatoField', name: 'Potato Field', category: 'food', cost: { scrap: 0, wood: 20, plank: 0, metal: 0 }, cycleTimeSec: 8, harvestAmount: 3, outputResource: 'food', outputValue: 1, seasonSpeedKey: 'farmingSpeed', seasonYieldKey: 'farmingYield', startsWithCount: 1 },
+  cornField: { id: 'cornField', name: 'Corn Field', category: 'food', cost: { scrap: 0, wood: 30, plank: 0, metal: 0 }, cycleTimeSec: 5, harvestAmount: 1, outputResource: 'food', outputValue: 2, seasonSpeedKey: 'farmingSpeed', seasonYieldKey: 'farmingYield', startsWithCount: 0 },
+  ricePaddy: { id: 'ricePaddy', name: 'Rice Paddy', category: 'food', cost: { scrap: 0, wood: 15, plank: 0, metal: 0 }, cycleTimeSec: 3, harvestAmount: 1, outputResource: 'food', outputValue: 1, seasonSpeedKey: 'farmingSpeed', seasonYieldKey: 'farmingYield', startsWithCount: 0 },
+
+  loggingCamp: { id: 'loggingCamp', name: 'Logging Camp', category: 'resources', cost: { scrap: 50, wood: 0, plank: 0, metal: 0 }, cycleTimeSec: 6, harvestAmount: 1, outputResource: 'wood', outputValue: 1, seasonSpeedKey: 'workSpeed', seasonYieldKey: 'workYield', startsWithCount: 1 },
+  sawmill: { id: 'sawmill', name: 'Sawmill', category: 'resources', cost: { scrap: 30, wood: 40, plank: 10, metal: 0 }, cycleTimeSec: 4, harvestAmount: 1, outputResource: 'plank', outputValue: 1, seasonSpeedKey: 'workSpeed', seasonYieldKey: 'workYield', startsWithCount: 0 },
+  scrapYard: { id: 'scrapYard', name: 'Scrap Yard', category: 'resources', cost: { scrap: 0, wood: 0, plank: 0, metal: 0 }, cycleTimeSec: 7, harvestAmount: 1, outputResource: 'scrap', outputValue: 1, seasonSpeedKey: 'workSpeed', seasonYieldKey: 'workYield', startsWithCount: 0 },
+  smelter: { id: 'smelter', name: 'Smelter', category: 'industry', cost: { scrap: 100, wood: 50, plank: 20, metal: 0 }, cycleTimeSec: 10, harvestAmount: 1, outputResource: 'metal', outputValue: 1, seasonSpeedKey: 'smeltingSpeed', seasonYieldKey: 'smeltingYield', startsWithCount: 0 },
+
+  granary: { id: 'granary', name: 'Granary', category: 'storage', cost: { scrap: 20, wood: 60, plank: 10, metal: 0 }, addsCapacity: { food: 200 }, startsWithCount: 0 },
+  warehouse: { id: 'warehouse', name: 'Warehouse', category: 'storage', cost: { scrap: 30, wood: 80, plank: 20, metal: 0 }, addsCapacity: { wood: 200, scrap: 200 }, startsWithCount: 0 }
+};
+
+export const SEASONS = {
+  spring: { farmingSpeed: 1.1, farmingYield: 1.1, workSpeed: 1, workYield: 1, smeltingSpeed: 1, smeltingYield: 1, seasonRain: 1.2 },
+  summer: { farmingSpeed: 1, farmingYield: 1, workSpeed: 1, workYield: 1, smeltingSpeed: 1, smeltingYield: 1, seasonRain: 1 },
+  autumn: { farmingSpeed: 0.9, farmingYield: 1, workSpeed: 1, workYield: 1.1, smeltingSpeed: 1, smeltingYield: 1, seasonRain: 0.8 },
+  winter: { farmingSpeed: 0.7, farmingYield: 0.8, workSpeed: 0.9, workYield: 0.9, smeltingSpeed: 1, smeltingYield: 1, seasonRain: 0.5 }
+};
+


### PR DESCRIPTION
## Summary
- Add comprehensive resource, building, and season definitions
- Implement sidebar with category grouping, capacities, rates, and seasonal production
- Support build/demolish actions with scaling costs and partial refunds

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a05f5c9b88331ab49ca7f8f8bf5d9